### PR TITLE
Fix initialize light leaks

### DIFF
--- a/lib/components/light_leaks/sync.js
+++ b/lib/components/light_leaks/sync.js
@@ -42,9 +42,9 @@ module.exports = class extends DisplaySynchronic {
   }
 
   changeParams(params, time) {
-    const promises = [super.changeParams(params, time)];
     const toInitialize = params.visible !== this.displayObject.visible ||
                          params.interval !== this._interval;
+    const promises = [super.changeParams(params, time)];
 
     if (toInitialize) {
       this._interval = params.interval;


### PR DESCRIPTION
以前の実装では、`toInitialize`に代入するときは`this.displayObject.visible`の値が`params.visible`と同じ値になっていた。`super.changeParams`はPromiseに限らないため順序を変更。

